### PR TITLE
Add podspec, resolve XCTest warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 .DS_Store
+.swiftpm

--- a/Sources/sMock/sMock.swift
+++ b/Sources/sMock/sMock.swift
@@ -222,7 +222,10 @@ private extension sMock {
         }
         
         private func reportFailure(_ description: String) {
-            MocksSupport.shared.currentTestCase.recordFailure(withDescription: description, inFile: _file, atLine: _line, expected: true)
+            let location = XCTSourceCodeLocation(filePath: _file, lineNumber: _line)
+            let context = XCTSourceCodeContext(location: location)
+            let issue = XCTIssue(type: .assertionFailure, compactDescription: description, detailedDescription: nil, sourceCodeContext: context, associatedError: nil, attachments: [])
+            MocksSupport.shared.currentTestCase.record(issue)
         }
     }
 }

--- a/sMock.podspec
+++ b/sMock.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |spec|
+  spec.name         = "sMock"
+  spec.version      = "1.1.0"
+  spec.summary      = "Swift mock-helping library written with gMock (C++) library approach in mind"
+  spec.description  = <<-DESC
+                   Swift mock-helping library written with gMock (C++) library approach in mind;
+                   uses XCTestExpectations inside, that makes sMock not only mocking library, but also library that allows easy unit-test coverage of mocked objects expected behavior;
+                   lightweight and zero-dependecy;
+                   works out-of-the-box without need of generators, tools, etc;
+                   required minimum of additional code to prepare mocks.
+                   DESC
+  spec.homepage     = "https://github.com/Alkenso/sMock"
+  spec.license      = "MIT"
+  spec.author             = { "Vladimir Alkenso" => "alkensox@gmail.com" }
+  spec.source       = { :git => "https://github.com/spin-org/sMock.git", :tag => "#{spec.version}" }
+  spec.source_files  = "Sources/sMock/**/*.swift"
+  spec.swift_versions = '5.0'
+
+  spec.platform = :ios, '11.0'
+  spec.framework = 'XCTest'
+end


### PR DESCRIPTION
We ran into an issue with SwiftPM and needed to start using pods for this. Here's the podspec for sMock in case you are interested.